### PR TITLE
Support GLIBC Version Targeting

### DIFF
--- a/cmake/zig-toolchain.cmake
+++ b/cmake/zig-toolchain.cmake
@@ -8,11 +8,11 @@ if(NOT DEFINED ZIG_TARGET)
     get_filename_component(PARENT_LIST_DIR "${CMAKE_PARENT_LIST_FILE}" DIRECTORY)
     string(FIND "${CMAKE_CURRENT_LIST_DIR}" "${PARENT_LIST_DIR}" POS)
     if(POS EQUAL 0)
-        get_filename_component(ZIG_TARGET "${CMAKE_PARENT_LIST_FILE}" NAME_WE)
+        get_filename_component(ZIG_TARGET "${CMAKE_PARENT_LIST_FILE}" NAME_WLE)
     endif()
 endif()
 
-if(NOT ZIG_TARGET MATCHES "^([a-zZ-Z0-9_]+)-([a-zZ-Z0-9_]+)-([a-zZ-Z0-9_]+)$")
+if(NOT ZIG_TARGET MATCHES "^([a-zZ-Z0-9_]+)-([a-zZ-Z0-9_]+)-([a-zZ-Z0-9_.]+)$")
     message(FATAL_ERROR "Expected ZIG_TARGET=<arch>-<os>-<abi>")
 endif()
 


### PR DESCRIPTION
Support GLIBC version targeting, example:

`cmake -B build -G Ninja --toolchain cmake/x86_64-linux-gnu.2.17.cmake` (You would need to create this file)

Because `NAME_WL` was used all extension info was lost, with `NAME_WLE` along with the regex change on the ABI match group we're able to recover and use the full ABI target string from the filename.

https://github.com/ziglang/zig/tree/master/lib/libc/glibc#zig-gnu-c-library-glibc-support